### PR TITLE
Update dotty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,53 @@
+{
+  "name": "mongo-graph",
+  "version": "0.0.4",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "json-format": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-format/-/json-format-1.0.1.tgz",
+      "integrity": "sha1-FD9n5irxKda//tKIpGJl6iPQ3ww=",
+      "dev": true
+    },
+    "npm-force-resolutions": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/npm-force-resolutions/-/npm-force-resolutions-0.0.10.tgz",
+      "integrity": "sha512-Jscex+xIU6tw3VsyrwxM1TeT+dd9Fd3UOMAjy6J1TMpuYeEqg4LQZnATQO5vjPrsARm3und6zc6Dii/GUyRE5A==",
+      "dev": true,
+      "requires": {
+        "json-format": "^1.0.1",
+        "source-map-support": "^0.5.5",
+        "xmlhttprequest": "^1.8.0"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   },
   "scripts": {
     "prepublish": "make",
-    "test": "make test"
+    "test": "make test",
+    "preinstall": "npx npm-force-resolutions",
+    "postshrinkwrap": "npx npm-force-resolutions"
   },
   "license": "BSD",
   "dependencies": {
@@ -20,5 +22,11 @@
     "dotty": "0.0.2",
     "JSONStream": "~0.6.4",
     "srand": "~1.1.3"
+  },
+  "devDependencies": {
+    "npm-force-resolutions": "0.0.10"
+  },
+  "resolutions": {
+    "dotty": "^0.1.2"
   }
 }


### PR DESCRIPTION
dotty 0.0.1 is outdated and vulnerable (CVE-2021-23624, CVE-2021-25912).

Per SECNG-938, let us update this dependency to 0.1.2 or above.